### PR TITLE
Fix units documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ otsql support trace with opentelemetry by `hook/trace`.
 otsql support metric with prometheus by `hook/metric`.
 
 | Metric                 | Search suffix  | Tags                                 |
-| ---------------------- | -------------- | ------------------------------------ |
-| Latency in millisecond | go_sql_latency | sql_instance, sql_method, sql_status |
+|------------------------| -------------- | ------------------------------------ |
+| Latency in microsecond | go_sql_latency | sql_instance, sql_method, sql_status |
 
 You can use `metric.Stats` to monitor connection pool, all metric supprt tag `sql_instance`.
 | Metric | Search suffix |
@@ -115,7 +115,7 @@ You can use `metric.Stats` to monitor connection pool, all metric supprt tag `sq
 | The total number of connections wait for | go_sql_conn_wait |
 | The total number of connections closed because of SetMaxIdleConns | go_sql_conn_idle_closed |
 | The total number of connections closed because of SetConnMaxLifetime | go_sql_conn_lifetime_closed |
-| The total time blocked by waiting for a new connection, nanosecond | go_sql_conn_wait_ns |
+| The total time blocked by waiting for a new connection, millisecond | go_sql_conn_wait_ms |
 
 ## Test
 

--- a/hook/metric/dbstats.go
+++ b/hook/metric/dbstats.go
@@ -74,7 +74,7 @@ var (
 	ConnLifetimeClosed = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "go_sql_conn_lifetime_closed",
-			Help: "The total number of connections closed becase of SetConnMaxLifetime",
+			Help: "The total number of connections closed because of SetConnMaxLifetime",
 		},
 		[]string{sqlInstance},
 	)

--- a/hook/metric/option.go
+++ b/hook/metric/option.go
@@ -49,7 +49,7 @@ var (
 	DefaultLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "go_sql_latency",
-			Help: "The latency of sql calls in milliseconds.",
+			Help: "The latency of sql calls in microseconds.",
 		},
 		[]string{sqlInstance, sqlDatabase, sqlMethod, sqlStatus},
 	)


### PR DESCRIPTION
* Log latency entries use nanoseconds (time.Duration) converted later to milliseconds by logger
* Latency uses microseconds (see hook/metric/hook.go:30)
* Connection blocking wait uses milliseconds  (see hook/metric/dbstats.go:30)
